### PR TITLE
capture unusual cases where no map defined in HMM

### DIFF
--- a/lib/Bio/HMM/Logo.c
+++ b/lib/Bio/HMM/Logo.c
@@ -71,6 +71,16 @@ ERROR:
 }
 
 SV*
+inline_check_map_defined(SV *hmm_p) {
+    int status = 0;
+    P7_HMM       *hmm       = c_obj(hmm_p, P7_HMM);
+    if (hmm->flags & p7H_MAP)
+        return newSViv(1);
+    else
+        return newSViv(0);
+}
+
+SV*
 inline_get_relative_entropy_all (SV *hmm_p) {
   int           status;
   int           i, j;

--- a/lib/Bio/HMM/Logo.pm
+++ b/lib/Bio/HMM/Logo.pm
@@ -84,6 +84,9 @@ sub hmmToLogo {
     die "$hmmfile does not exist on disk!\n";
   }
   my $hmm = inline_read_hmm($hmmfile);
+  unless (inline_check_map_defined($hmm)) {
+    die "$hmmfile does not appear to have an alignment map (required)";
+  }
   my $abc = inline_get_abc($hmm);
 
   my $alph     = inline_get_alphabet_string($abc);


### PR DESCRIPTION
We have some HMMs without maps - i.e.:

`MAP   no`

that cause a seg fault when trying to build logos.